### PR TITLE
Implemented: method to pass signature to clover api if required (#2vpy2q)

### DIFF
--- a/src/android/CloverGo.java
+++ b/src/android/CloverGo.java
@@ -76,10 +76,7 @@ import com.firstdata.clovergo.domain.model.Order;
 import com.firstdata.clovergo.domain.model.Payment;
 import com.firstdata.clovergo.domain.model.ReaderInfo;
 
-
 import static com.firstdata.clovergo.domain.model.ReaderInfo.ReaderType.RP450;
-import com.clover.sdk.v3.order.PayType;
-import static com.clover.sdk.v3.order.PayType.FULL;
 
 /**
  * The class perform payment operations with Clover Go device

--- a/www/CloverGo.js
+++ b/www/CloverGo.js
@@ -10,6 +10,9 @@ var clovergo = {
     sale: function (saleInfo, successCallback, errorCallback) {
         exec(successCallback, errorCallback, 'CloverGo', 'sale', [saleInfo]);
     },
+    sign: function (signInfo, successCallback, errorCallback) {
+        exec(successCallback, errorCallback, 'CloverGo', 'sign', [signInfo]);
+    },
     disconnect: function (successCallback, errorCallback) {
         exec(successCallback, errorCallback, 'CloverGo', 'disconnect', []);
     }


### PR DESCRIPTION
Additional changes:
Handled onSendReceipt to not to send any receipt and in case of confirmation for challenges accept it by default for now